### PR TITLE
Fix colours for dark themes (and themes in general)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ js/*.map
 build
 .phpunit.result.cache
 .phpunit.cache
+
+# Editor files
+
+.vscode/
+.idea/
+*.iml

--- a/Makefile
+++ b/Makefile
@@ -115,13 +115,13 @@ dist:
 source:
 	rm -rf $(source_build_directory)
 	mkdir -p $(source_build_directory)
-	tar cvzf $(source_package_name).tar.gz ../$(app_name) \
-	--exclude-vcs \
-	--exclude="../$(app_name)/build" \
-	--exclude="../$(app_name)/js/node_modules" \
-	--exclude="../$(app_name)/node_modules" \
-	--exclude="../$(app_name)/*.log" \
-	--exclude="../$(app_name)/js/*.log" \
+	tar --exclude-vcs \
+        --exclude="../$(app_name)/build" \
+        --exclude="../$(app_name)/js/node_modules" \
+        --exclude="../$(app_name)/node_modules" \
+        --exclude="../$(app_name)/*.log" \
+        --exclude="../$(app_name)/js/*.log" \
+        -czf $(source_package_name).tar.gz ../$(app_name)
 
 # Builds the source package for the app store, ignores php and js tests
 .PHONY: appstore

--- a/src/Editor.vue
+++ b/src/Editor.vue
@@ -127,6 +127,11 @@ export default {
 	color: var(--color-main-text) !important;
 }
 
+.editor-preview {
+	background-color: var(--color-main-background);
+	color: var(--color-main-text);
+}
+
 .CodeMirror {
 	background-color: var(--color-main-background);
 	color: var(--color-main-text);

--- a/src/Editor.vue
+++ b/src/Editor.vue
@@ -146,6 +146,15 @@ export default {
 	border-color: var(--color-main-text);
 }
 
+.editor-toolbar a.active, .editor-toolbar a:hover {
+	background-color: var(--color-background-hover) !important;
+}
+
+.editor-toolbar.disabled-for-preview a:not(.no-disable) {
+	background-color: var(--color-background-darker) !important;
+	color: var(--color-text-lighter) !important;
+}
+
 #entry-title {
 	padding-left: 1em;
 	padding-top: 0.5em;


### PR DESCRIPTION
This commit changes the Editor.vue file to explicitly set the colours of the preview and buttons.
The changes have been tested with the high contrast mode and dark theme, and so far nothing has shown to be incorrect.

Other changes:
- Fixed issue with `make source` not working because the arguments were ordered badly (I don't know why this issue appeared, but hopefully it's fixed).
- Added editor-specific file ignores to the .gitignore; currently only files from Visual Studio Code and IntelliJ-based editors are ignored.